### PR TITLE
Overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,16 +64,15 @@
         {
           clj-builder = prev.callPackage utils.clj-builder { };
 
-          deps-lock = prev.callPackage utils.deps-lock
-            {
-              inherit (final) clj-builder;
-            };
+          deps-lock = prev.callPackage utils.deps-lock {
+            inherit (final) clj-builder;
+          };
 
-          mkCljBin = attrs: prev.callPackage ./pkgs/mkCljBin.nix
-            ({ inherit (final) clj-builder; }
-            // attrs);
+          mkCljBin = prev.callPackage ./pkgs/mkCljBin.nix {
+            inherit (final) clj-builder;
+          };
 
-          mkGraalBin = attrs: prev.callPackage ./pkgs/mkGraalBin.nix attrs;
+          mkGraalBin = prev.callPackage ./pkgs/mkGraalBin.nix { };
 
           customJdk = prev.callPackage ./pkgs/customJdk.nix;
         };

--- a/pkgs/mkCljBin.nix
+++ b/pkgs/mkCljBin.nix
@@ -13,11 +13,12 @@ let default-lock-file = "deps-lock.json"; in
   # Used by clj tools.build to compile the code
 , jdk
 
-
-  # User options
-
+  # Custom utils
+, clj-builder
+}:
+{
   # Runtime jdk
-, jdkRunner ? jdk
+  jdkRunner ? jdk
 , projectSrc
 , name
 , version ? "DEV"
@@ -25,9 +26,6 @@ let default-lock-file = "deps-lock.json"; in
 , lock-file ? default-lock-file
 , compile ? true
 , java-opts ? [ ]
-
-  # Custom utils
-, clj-builder
 }:
 let
 


### PR DESCRIPTION
This adds a nixpkgs overlay.

I also refactored the packages a bit, moving the "user args" into a separate argument. Not sure if that's an actual improvement. Feel free to drop that commit.

One "issue" I noticed while working on this is, that neither of `mkCljBin`, `mkGraalBin` and `customJdk` are a derivation, so `nix flake show` errors when trying to list the `packages` output. This was the case before and after this PR though.