### PR TITLE
Set `pipefail` option in `deps-lock` script

### DIFF
--- a/pkgs/depsLock.nix
+++ b/pkgs/depsLock.nix
@@ -1,5 +1,6 @@
 { jq, writeShellScriptBin, nix-prefetch-git, clj-builder }:
 writeShellScriptBin "deps-lock"
   ''
+    set -o pipefail
     ${clj-builder} | ${jq}/bin/jq . > deps-lock.json
   ''


### PR DESCRIPTION
When porting one of our applications to `clj-nix` I played around a bit with a custom check to get notified by CI if the `deps-lock.json` should have been updated. I failed at first because even though I knew that it was only possible with `--no-sandbox` I didn't see any errors when calling it without this flag (the `deps-lock.json` is created anyway, but with size 0).

Looking at the `depsLock.nix` I saw that it's due to failure of `clj-builder` not leading to a non-zero exit code of the `deps-lock` script.

I think it's a good idea to set this option :)

Also thanks for this repo, it's been great so far! My colleague helped me to get started and so far I could even port our static-JS-from-CLJS-without-JAR parts by using `mk-deps-cache` directly. Developer ergonomics have improved a lot :)