### PR TITLE
Add an overlay (take 2)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         let
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [ inputs.devshell.overlay self.overlay ];
+            overlays = [ inputs.devshell.overlay self.overlays.default ];
           };
         in
         {
@@ -28,7 +28,7 @@
 
           };
 
-          devShell =
+          devShells.default =
             pkgs.devshell.mkShell {
               packages = [
                 pkgs.nix-prefetch-git
@@ -57,17 +57,23 @@
               ];
             };
 
+          # Deprecated
+          devShell = self.devShells.${system}.default;
+
         }) //
 
    {
       lib = import ./helpers.nix;
 
-      defaultTemplate = {
+      templates.default = {
         path = ./templates/default;
         description = "A simple clj-nix project";
       };
 
-      overlay = final: prev: {
+      # Deprecated
+      defaultTemplate = self.templates.default;
+
+      overlays.default = final: prev: {
         clj-builder = final.callPackage ./pkgs/cljBuilder.nix { };
         deps-lock = final.callPackage ./pkgs/depsLock.nix { };
         mk-deps-cache = final.callPackage ./pkgs/mkDepsCache.nix;
@@ -76,6 +82,8 @@
         mkGraalBin = final.callPackage ./pkgs/mkGraalBin.nix { };
         customJdk = final.callPackage ./pkgs/customJdk.nix { };
       };
-    };
 
+      # Deprecated
+      overlay = self.overlays.default;
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,6 @@
       (system:
         let
           pkgs = inputs.nixpkgs.legacyPackages.${system};
-          utils = import ./pkgs/utils.nix;
         in
         {
           packages = {


### PR DESCRIPTION
Since I'd love to use this as an actual overlay at work, and #13 seems to be a bit stalled, with the call for someone else to do it, I figured I might just do it :)

I've added an overlay output. This also simplifies the `callPackage` invocations, as when called with `final` (where the `clj-nix` packages are already contained), one does not need to pass the necessary arguments like `clj-builder` via `self`; it just works.

I've also added @Sohalt as co-author, since he did the same kind of work earlier.

This is in principle ready to merge I think. I tried this in our work project and the functions I use are still working nicely. I'd love if anyone else could try it out, too, as I'm not using all the features.

One more thing, though: In more recent versions of nix the flake outputs `overlay`, `devShell`, `defaultTemplate` are deprecated in favor of the more uniform `overlays.default`, `devShells.default`, `templates.default`. @jlesquembre Would you mind me putting this in here as well, as separate commit and preserving backwards compatibility? It doesn't really fit in a separate PR, as this one changes the structure so much already.