### PR TITLE
Support multi-release jars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
-- Fix mkCljCli helper function
+- Fix `mkCljCli` helper function
 - Add support for Leiningen projects
-- Add lockfile option to mkCljBin
-- Add mkBabashka
+- Add `lockfile` option to `mkCljBin`
+- Add `mkBabashka`
 - Add `bbTasksFromFile`
+- Add `multiRelease` option to `customJdk`
 
 ## 0.2.0 (2022-06-13)
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,13 @@ default are mandatory):
   be used to analyze the `cljDrv` and pick the necessary modules automatically.
   (Default: `null`)
 
+- **multiRelease**: Option passed to jdeps `--multi-release`. Should be an
+  integer >=9 or a boolean. If true, the value is set to `base`. If false or not
+  specified, clj-nix will try to detect if the jar is a multi-release jar and
+  set the value automatically. See
+  [The jdeps Command](https://docs.oracle.com/en/java/javase/17/docs/specs/man/jdeps.html)
+  for more info. (Default: `false`)
+
 - **locales**: Option passed to jlink `--include-locales`. (Default: `null`)
 
 **Example**:

--- a/pkgs/customJdk.nix
+++ b/pkgs/customJdk.nix
@@ -38,7 +38,7 @@ let
   multiRelease-args =
     if multiRelease == false then ""
     else if multiRelease == true then "--multi-release base --ignore-missing-deps"
-    else "--multi-release ${multiRelease} --ignore-missing-deps";
+    else "--multi-release ${builtins.toString multiRelease} --ignore-missing-deps";
 
 in
 stdenv.mkDerivation ({

--- a/pkgs/customJdk.nix
+++ b/pkgs/customJdk.nix
@@ -11,6 +11,7 @@
   # Manually set the modules
 , jdkModules ? null
 , locales ? null
+, multiRelease ? false
 , ...
 }@attrs:
 
@@ -34,6 +35,11 @@ let
     '';
 
   jarPath = lib.fileContents "${cljDrv}/nix-support/jar-path";
+  multiRelease-args =
+    if multiRelease == false then ""
+    else if multiRelease == true then "--multi-release base --ignore-missing-deps"
+    else "--multi-release ${multiRelease} --ignore-missing-deps";
+
 in
 stdenv.mkDerivation ({
   inherit locales template jdkModules;
@@ -65,7 +71,7 @@ stdenv.mkDerivation ({
       ''
     else
       ''
-        export jdkModules=$(jdeps --print-module-deps "${jarPath}")
+        export jdkModules=$(jdeps ${multiRelease-args} --print-module-deps "${jarPath}")
       '')
     +
 


### PR DESCRIPTION
@thenonameguy Could you take a look? If looks ok to you, I'll merge it. 
I did some tests, and it seems to work, but I didn't find what the `--multi-release base` flag exactly does.

I have a multi-release jar example here:
https://github.com/jlesquembre/clj-demo-project/tree/multirelease

To build the custom JDK run `nix build github:jlesquembre/clj-demo-project/multirelease#jdk-tuto`, or `nix build .#jdk-tuto`

Fixes #20 