### PR TITLE
breaking: remove hidden/dotfiles from deps-lock by default

### DIFF
--- a/src/cljnix/core.clj
+++ b/src/cljnix/core.clj
@@ -332,6 +332,7 @@
    (fs/with-temp-dir [cache-dir {:prefix "clj-cache"}]
      (transduce
        (comp
+         ;; NOTE: the globbing below return $PREFIXdeps.edn files, we need to filter still
          (filter #(= "deps.edn" (fs/file-name %)))
          (remove #(some (partial fs/ends-with? %) deps-ignore))
          (map (juxt identity #(-> % deps/slurp-deps :aliases keys)))
@@ -373,7 +374,7 @@
 
        {:mvn extra-mvn
         :git extra-git}
-       (file-seq (fs/file project-dir))))))
+       (fs/glob project-dir "**deps.edn")))))
 
 (defn -main
   [& [flag value & more :as args]]

--- a/src/cljnix/utils.clj
+++ b/src/cljnix/utils.clj
@@ -193,12 +193,13 @@
 
 (defn expand-shas!
   [project-dir]
-  (let [dep-files (filter #(= "deps.edn" (str (fs/file-name %)))
-                          (file-seq (fs/file project-dir)))
+  (let [dep-paths (filter
+                   #(= "deps.edn" (fs/file-name %))
+                   (fs/glob project-dir "**deps.edn"))
         {:keys [git-deps]} (json/read-str
                             (slurp (str (fs/path project-dir "deps-lock.json")))
                             :key-fn keyword)]
-    (doseq [my-deps dep-files
+    (doseq [my-deps dep-paths
             :let [deps (deps/slurp-deps (fs/file my-deps))
                   git-deps-paths (paths-to-gitdeps deps)
                   partial-sha-paths (->> git-deps-paths

--- a/src/cljnix/utils.clj
+++ b/src/cljnix/utils.clj
@@ -199,8 +199,8 @@
         {:keys [git-deps]} (json/read-str
                             (slurp (str (fs/path project-dir "deps-lock.json")))
                             :key-fn keyword)]
-    (doseq [my-deps dep-paths
-            :let [deps (deps/slurp-deps (fs/file my-deps))
+    (doseq [my-deps (mapv fs/file dep-paths)
+            :let [deps (deps/slurp-deps my-deps)
                   git-deps-paths (paths-to-gitdeps deps)
                   partial-sha-paths (->> git-deps-paths
                                          (filter #(partial-sha? (get-in deps %)))


### PR DESCRIPTION
I'm using direnv in my projects + a top-level deps-lock.json The cache folder of direnv puts paths into the file-seq:

```
.direnv/flake-inputs/9zrqx8iyyh1ss30qnz65620sb293301n-source/backend/deps.edn
```

These should be IMO removed by default and are hard to remove with the current deps-ignore since the path string overlaps with my wanted deps.edn paths.

This is a breaking change, but IMO it should be not a huge concern for most normal use-cases.

Changing the implementation to use [`fs/glob`](https://github.com/babashka/fs/blob/master/API.md#glob-page_facing_up) automatically does this filtering.