### PR TITLE
Fix mkCljLib and bring it closer to mkCljApp featureset

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -138,7 +138,7 @@ Takes the following attributes (those without a default are mandatory):
 - **cljDrv**: Derivation generated with `mkCljBin`.
 
 - **graalvm**: GraalVM used at build time. (Default:
-  `nixpkgs.graalvmCEPackages.graalvm19-ce`)
+  `nixpkgs.graalvm-ce`)
 
 - **name**: Derivation name. (Default: `cljDrv.name`)
 
@@ -205,7 +205,7 @@ Takes the following attributes:
 - **bbLean**: Disable default Babashka features. (Default: `false`)
 
 - **graalvm**: GraalVM used at build time. (Default:
-  `nixpkgs.graalvmCEPackages.graalvm19-ce`)
+  `nixpkgs.graalvm-ce`)
 
 - **wrap**: Create a wrapper with `rlwrap` (Default: `true`)
 

--- a/extra-pkgs/babashka/default.nix
+++ b/extra-pkgs/babashka/default.nix
@@ -5,13 +5,13 @@
 , rlwrap
 , makeWrapper
 , writeShellApplication
-, graalvmCEPackages
+, graalvm-ce
 , nix-package-updater
 , srcFromJson
 , writeScriptBin
 }:
 
-{ graalvm ? graalvmCEPackages.graalvm19-ce
+{ graalvm ? graalvm-ce
 , withFeatures ? [ ]
 , bbLean ? false
 , wrap ? true

--- a/extra-pkgs/docs/default.nix
+++ b/extra-pkgs/docs/default.nix
@@ -1,9 +1,4 @@
-{ self
-, stdenv
-, python311Packages
-
-, pkgs
-}:
+{ stdenv, python311Packages, pkgs, ... }:
 
 let
   inherit (pkgs) lib;

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
             packages = [
               pkgs.jq
               pkgs.clojure
-              pkgs.graalvmCEPackages.graalvm19-ce
+              pkgs.graalvm-ce
               pkgs.bats
               pkgs.envsubst
               pkgs.mustache-go

--- a/modules/top-level.nix
+++ b/modules/top-level.nix
@@ -138,8 +138,8 @@ let types = lib.types; in
           };
 
           graalvm = lib.mkOption {
-            default = pkgs.graalvmCEPackages.graalvm19-ce;
-            defaultText = lib.literalExpression "pkgs.graalvmCEPackages.graalvm19-ce";
+            default = pkgs.graalvm-ce;
+            defaultText = lib.literalExpression "pkgs.graalvm-ce";
             type = types.package;
             description = lib.mdDoc "GraalVM used at build time";
           };

--- a/pkgs/mkCljLib.nix
+++ b/pkgs/mkCljLib.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation ({
   patchPhase =
     ''
       runHook prePatch
-      ${clj-builder} patch-git-sha "$(pwd)"
+      ${clj-builder}/bin/clj-builder patch-git-sha "$(pwd)"
       runHook postPatch
     '';
 
@@ -75,7 +75,7 @@ stdenv.mkDerivation ({
     (
       if builtins.isNull buildCommand then
         ''
-          ${clj-builder} jar "${fullId}" "${version}"
+          ${clj-builder}/bin/clj-builder jar "${fullId}" "${version}"
         ''
       else
         ''

--- a/pkgs/mkCljLib.nix
+++ b/pkgs/mkCljLib.nix
@@ -28,6 +28,7 @@ let
     "version"
     "buildCommand"
     "maven-extra"
+    "nativeBuildInputs"
   ];
 
   deps-cache = mk-deps-cache {
@@ -48,10 +49,12 @@ stdenv.mkDerivation ({
 
   # Build time deps
   nativeBuildInputs =
-    [
-      jdk
-      clojure
-    ];
+    attrs.nativeBuildInputs or [ ]
+      ++
+      [
+        jdk
+        clojure
+      ];
 
   passthru = {
     inherit fullId groupId artifactId;

--- a/pkgs/mkGraalBin.nix
+++ b/pkgs/mkGraalBin.nix
@@ -4,16 +4,16 @@
 { lib
 , stdenv
 , fetchurl
-, graalvmCEPackages
 , glibcLocales
 , writeShellScript
+, graalvm-ce
 , writeText
 }:
 
 { cljDrv
 , name ? cljDrv.pname
 , version ? cljDrv.version
-, graalvm ? graalvmCEPackages.graalvm19-ce
+, graalvm ? graalvm-ce
 
 , nativeBuildInputs ? [ ]
 


### PR DESCRIPTION
I was trying to package https://github.com/schemamap/pg-query-clj/ and ran into issues with using mkCljLib.
The real fix is: clj-builder being a derivation now, instead of the shell script directly.