### PR TITLE
Add .clj-kondo/.cache to *path-filter*

### DIFF
--- a/src/cljnix/nix.clj
+++ b/src/cljnix/nix.clj
@@ -3,7 +3,8 @@
     [clojure.java.io :as io]
     [babashka.fs :as fs]
     [clj-commons.byte-streams :as bs]
-    [cljnix.utils :refer [throw+]])
+    [cljnix.utils :refer [throw+]]
+    [clojure.string :as str])
   (:import
     [java.io ByteArrayOutputStream]
     [java.nio ByteBuffer ByteOrder]
@@ -18,7 +19,8 @@
   *path-filter*
  "Takes 1 argument, the path name. If true, the element will not be included in
  the NAR file"
- #{".git"})
+ #{".git"
+   ".clj-kondo/.cache"})
 
 
 (declare serialize-entry)
@@ -114,7 +116,9 @@
       (str! "type")
       (str! "directory"))
   (doseq [entry (sort-by fs/file-name
-                         (remove (comp *path-filter* fs/file-name)
+                         (remove (fn [fl]
+                                   (some #(str/ends-with? (str fl) (str "/" %))
+                                         *path-filter*))
                                  (fs/list-dir path)))]
     (serialize-entry sink entry))
   sink)

--- a/src/cljnix/nix.clj
+++ b/src/cljnix/nix.clj
@@ -3,7 +3,7 @@
     [clojure.java.io :as io]
     [babashka.fs :as fs]
     [clj-commons.byte-streams :as bs]
-    [cljnix.utils :refer [throw+]]
+    [cljnix.utils :refer [throw+]])
   (:import
     [java.io ByteArrayOutputStream]
     [java.nio ByteBuffer ByteOrder]

--- a/src/cljnix/nix.clj
+++ b/src/cljnix/nix.clj
@@ -4,7 +4,6 @@
     [babashka.fs :as fs]
     [clj-commons.byte-streams :as bs]
     [cljnix.utils :refer [throw+]]
-    [clojure.string :as str])
   (:import
     [java.io ByteArrayOutputStream]
     [java.nio ByteBuffer ByteOrder]
@@ -116,9 +115,7 @@
       (str! "type")
       (str! "directory"))
   (doseq [entry (sort-by fs/file-name
-                         (remove (fn [fl]
-                                   (some #(str/ends-with? (str fl) (str "/" %))
-                                         *path-filter*))
+                         (remove (fn [child] (some #(fs/ends-with? child %) *path-filter*))
                                  (fs/list-dir path)))]
     (serialize-entry sink entry))
   sink)


### PR DESCRIPTION
I had some problems with `.clj-kondo/.cache` folder being created in gitlibs causing a sha mismatch.

This patch adds `.clj-kondo/.cache` to `*path-filter*`. In order for this to work, I also had to change the filter to use `str/ends-with?`.