### PR TITLE
Add support to git dependencies in private/ssh repositories

### DIFF
--- a/docs/lock-file.md
+++ b/docs/lock-file.md
@@ -53,7 +53,7 @@ There is also a `--alias-include` option, to include only certain aliases.
 #### Git dependencies in private/ssh repositories
 
 In order to use the nix builtin fetcher on a git dependency, add a key-value
-`:clj-nix.git/fetch :builtins.fetchTree` to the dependency in deps.edn, e.g.
+`:clj-nix.git/fetch :builtins.fetchTree` to the dependency in `deps.edn`, e.g.
 
 ```edn
 {:deps {private/dependency {:git/url "git@private.host:secret/repo.git"
@@ -61,7 +61,7 @@ In order to use the nix builtin fetcher on a git dependency, add a key-value
                             :clj-nix.git/fetch :builtins.fetchTree}}}
 ```
 
-This should work well in any cases where a repository can be accessed
+This should work well in many cases where a repository can be accessed
 with the help of ssh-agent or other credential mechanisms, that nix
 builtin fetch supports.
 

--- a/docs/lock-file.md
+++ b/docs/lock-file.md
@@ -50,6 +50,25 @@ nix run github:jlesquembre/clj-nix#deps-lock -- --alias-exclude test
 
 There is also a `--alias-include` option, to include only certain aliases.
 
+#### Git dependencies in private/ssh repositories
+
+In order to use the nix builtin fetcher on a git dependency, add a key-value
+`:clj-nix.git/fetch :builtins.fetchTree` to the dependency in deps.edn, e.g.
+
+```edn
+{:deps {private/dependency {:git/url "git@private.host:secret/repo.git"
+                            :git/sha "0000000000000000000000000000000000000000"
+                            :clj-nix.git/fetch :builtins.fetchTree}}}
+```
+
+This should work well in any cases where a repository can be accessed
+with the help of ssh-agent or other credential mechanisms, that nix
+builtin fetch supports.
+
+The trade-off (and reason that's not the default) is, that the
+dependency will be fetched at evaluation time, causing downloads even
+during `--dry-run`; Pending resolution of an [issue in nix](https://github.com/NixOS/nix/issues/9077).
+
 #### Babashka dependencies
 
 Dependencies on `bb.edn` files can be added to the `deps-lock.json` file:

--- a/pkgs/mkDepsCache.nix
+++ b/pkgs/mkDepsCache.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenvNoCC
 , fetchurl
 , fetchgit
 , jdk
@@ -47,21 +46,19 @@ let
       # we're using builtins.fetchGit, instead of fetchgit from
       # build-support, so that we have seamless integration with
       # ssh-agent or other credential mechanisms.
-      path = stdenvNoCC.mkDerivation {
-        name = "${lib}/${rev}";
+      path = runCommand "${lib}/${rev}" {
         src = builtins.fetchGit {
           inherit url rev;
           allRefs = true;
         };
-        installPhase = ''
-          cp -R $src $out
-        '';
         # we're wrapping builtins.fetchGit with a fixed-output
         # derivation, re-using the same hash, that the fetchgit would
         # use, from the prefetcher
         outputHashMode = "recursive";
         outputHash = hash;
-      };
+      } ''
+        cp -R $src $out
+      '';
     };
 
   maven-extra-cache = { path, content }:

--- a/pkgs/mkDepsCache.nix
+++ b/pkgs/mkDepsCache.nix
@@ -52,6 +52,9 @@ let
         allRefs = true;
         narHash = hash;
         inherit url rev;
+        # deep cloning is necessary, for allRefs to work
+        # See https://nix.dev/manual/nix/latest/language/builtins.html#source-types
+        shallow = false;
       };
     };
 

--- a/pkgs/mkDepsCache.nix
+++ b/pkgs/mkDepsCache.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenvNoCC
 , fetchurl
 , fetchgit
 , jdk
@@ -43,9 +44,23 @@ let
     { lib, url, rev, hash, ... }:
     {
       name = "${lib}/${rev}";
-      path = builtins.fetchGit {
-        inherit url rev;
-        allRefs = true;
+      # we're using builtins.fetchGit, instead of fetchgit from
+      # build-support, so that we have seamless integration with
+      # ssh-agent or other credential mechanisms.
+      path = stdenvNoCC.mkDerivation {
+        name = "${lib}/${rev}";
+        src = builtins.fetchGit {
+          inherit url rev;
+          allRefs = true;
+        };
+        installPhase = ''
+          cp -R $src $out
+        '';
+        # we're wrapping builtins.fetchGit with a fixed-output
+        # derivation, re-using the same hash, that the fetchgit would
+        # use, from the prefetcher
+        outputHashMode = "recursive";
+        outputHash = hash;
       };
     };
 

--- a/pkgs/mkDepsCache.nix
+++ b/pkgs/mkDepsCache.nix
@@ -1,7 +1,6 @@
 { lib
 , fetchurl
 , fetchgit
-, openssh
 , jdk
 , runtimeShell
 , runCommand
@@ -45,14 +44,9 @@ let
     {
       name = "${lib}/${rev}";
       path = builtins.fetchGit {
-        inherit url rev; # hash;
+        inherit url rev;
         allRefs = true;
       };
-      # path = (fetchgit {
-      #   inherit url rev hash;
-      # }).overrideAttrs (_: {
-      #   GIT_SSH_COMMAND = "${openssh}/bin/ssh -o StrictHostKeyChecking=no";
-      # });
     };
 
   maven-extra-cache = { path, content }:

--- a/pkgs/mkDepsCache.nix
+++ b/pkgs/mkDepsCache.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchurl
 , fetchgit
+, openssh
 , jdk
 , runtimeShell
 , runCommand
@@ -43,9 +44,14 @@ let
     { lib, url, rev, hash, ... }:
     {
       name = "${lib}/${rev}";
-      path = fetchgit {
-        inherit url rev hash;
+      path = builtins.fetchGit {
+        inherit url rev; # hash;
       };
+      # path = (fetchgit {
+      #   inherit url rev hash;
+      # }).overrideAttrs (_: {
+      #   GIT_SSH_COMMAND = "${openssh}/bin/ssh -o StrictHostKeyChecking=no";
+      # });
     };
 
   maven-extra-cache = { path, content }:

--- a/pkgs/mkDepsCache.nix
+++ b/pkgs/mkDepsCache.nix
@@ -52,6 +52,7 @@ let
         allRefs = true;
         narHash = hash;
         inherit url rev;
+      };
     };
 
   maven-extra-cache = { path, content }:

--- a/pkgs/mkDepsCache.nix
+++ b/pkgs/mkDepsCache.nix
@@ -43,22 +43,15 @@ let
     { lib, url, rev, hash, ... }:
     {
       name = "${lib}/${rev}";
-      # we're using builtins.fetchGit, instead of fetchgit from
+      # we're using builtins.fetchTree, instead of fetchgit from
       # build-support, so that we have seamless integration with
       # ssh-agent or other credential mechanisms.
-      path = runCommand "${lib}/${rev}" {
-        src = builtins.fetchGit {
-          inherit url rev;
-          allRefs = true;
-        };
-        # we're wrapping builtins.fetchGit with a fixed-output
-        # derivation, re-using the same hash, that the fetchgit would
-        # use, from the prefetcher
-        outputHashMode = "recursive";
-        outputHash = hash;
-      } ''
-        cp -R $src $out
-      '';
+      # See https://nix.dev/manual/nix/latest/language/builtins.html#builtins-fetchTree
+      path = builtins.fetchTree {
+        type = "git";
+        allRefs = true;
+        narHash = hash;
+        inherit url rev;
     };
 
   maven-extra-cache = { path, content }:

--- a/pkgs/mkDepsCache.nix
+++ b/pkgs/mkDepsCache.nix
@@ -46,6 +46,7 @@ let
       name = "${lib}/${rev}";
       path = builtins.fetchGit {
         inherit url rev; # hash;
+        allRefs = true;
       };
       # path = (fetchgit {
       #   inherit url rev hash;

--- a/test/integration/fake_git_test.clj
+++ b/test/integration/fake_git_test.clj
@@ -34,8 +34,8 @@
     {:rev "rev2"
      :tag "v0.0.2"}]
     "tag --sort=v:refname"
-   ["v0.0.1"
-    "v0.0.2"]
+   ["v0.0.2"
+    "v0.0.1"]
    #(-> % :out)))
 
 (deftest fake-git-rev-parse-tag-test

--- a/test/integration/fake_git_test.clj
+++ b/test/integration/fake_git_test.clj
@@ -34,8 +34,8 @@
     {:rev "rev2"
      :tag "v0.0.2"}]
     "tag --sort=v:refname"
-   ["v0.0.2"
-    "v0.0.1"]
+   ["v0.0.1"
+    "v0.0.2"]
    #(-> % :out)))
 
 (deftest fake-git-rev-parse-tag-test

--- a/test/integration/fake_git_test.clj
+++ b/test/integration/fake_git_test.clj
@@ -34,9 +34,9 @@
     {:rev "rev2"
      :tag "v0.0.2"}]
     "tag --sort=v:refname"
-   ["v0.0.1"
-    "v0.0.2"]
-   #(-> % :out)))
+    #{"v0.0.1"
+      "v0.0.2"}
+   #(-> % :out set)))
 
 (deftest fake-git-rev-parse-tag-test
   (fake-git-test


### PR DESCRIPTION
fix https://github.com/jlesquembre/clj-nix/issues/70

#### implements Option 2: `Only builtins.fetchGit`

I've been running with this option since a year ago, to access my private git repositories. I feel that this is the best option:

Despite using it only with ssh urls myself, I feel like it's also a good bet for http urls, since those may also have credential integration, that `builtins.fetchGit` can access.