### PR TITLE
report clj build failures to stderr

### DIFF
--- a/pkgs/cljBuilder.nix
+++ b/pkgs/cljBuilder.nix
@@ -12,5 +12,6 @@ common.writeCljApplication {
   runtimeInputs = [ leiningen jdk ] ++ extra-runtime-inputs;
   clj-main = "cljnix.builder-cli";
   classpath = "${../src}:${common.internal-deps-classpath}";
-  inherit java-opts preBuild postBuild;
+  inherit preBuild postBuild;
+  java-opts = [ "-Dclojure.main.report=stderr" ] ++ java-opts;
 }


### PR DESCRIPTION
The default behavior of clojure to write error reports into `/tmp/clojure-*.edn` doesn't really work well in a nix builder: After the build concludes, the `edn` file is deleted, or rather, it never hit the disk because in the build sandbox, a fresh tmpfs is mounted on `/tmp`.

So it's better, to restore the old behavior and let clojure barf to stderr. Nix will keep it available via `nix log`.

#### Before

:fearful: :cry: 
```console
       > Full report at:
       > /tmp/clojure-17334729123361555966.edn
       For full logs, run 'nix log /nix/store/2xzw9b0jmlhwzwidqzgw6mcllqhn4i5d-directory-DEV.drv'.
```

#### After

:+1: :grin: 
```console
       > Execution error (NullPointerException) at rewrite-clj.custom-zipper.core/node (core.cljc:55).
       > Cannot invoke "clojure.lang.IFn.invoke(Object)" because "loc" is null
       >
       For full logs, run 'nix log /nix/store/qfigggf1jd6396zp5bjwiphnjwk1wlvz-directory-DEV.drv'.
```
 