### PR TITLE
Improve/fix Leiningen usage

### DIFF
--- a/docs/lock-file.md
+++ b/docs/lock-file.md
@@ -87,6 +87,9 @@ ignored files:
 nix run github:jlesquembre/clj-nix#deps-lock -- --lein
 ```
 
+By default, all custom profiles (if any) are merged to download the dependencies. 
+This can be customized with the `--lein-profiles` option.
+
 Keep in mind that `deps-lock` command is not optimized for Leiningen projects,
 it will download all the maven dependencies every time we generate the lock
 file. For that reason, it is recommended to add a `deps.edn` file with the same

--- a/helpers.nix
+++ b/helpers.nix
@@ -55,7 +55,7 @@ in
     );
 
     assert (pkgs'.lib.assertMsg
-      (cfg.withLeiningen == true -> cfg.compileCljOpts == false && cfg.javacOpts == false)
+      (cfg.withLeiningen == true -> isNull cfg.compileCljOpts && isNull cfg.javacOpts)
       "Leiningen is incompatible with Clojure tools.build options (compileCljOpts and javacOpts)"
     );
 

--- a/helpers.nix
+++ b/helpers.nix
@@ -73,6 +73,7 @@ in
         inherit (cfg) projectSrc name version main-ns buildCommand
           lockfile java-opts compileCljOpts javacOpts
           builder-extra-inputs builder-java-opts builder-preBuild builder-postBuild;
+        enableLeiningen = cfg.withLeiningen;
       };
     in
 

--- a/src/cljnix/core.clj
+++ b/src/cljnix/core.clj
@@ -308,7 +308,7 @@
     (let [profiles (or (seq profiles) (lein-project-profiles))]
       (if (empty? profiles)
         (sh/sh "lein" "deps" :env {"LEIN_HOME" lein-home})
-        (sh/sh "lein" "with-profiles" (string/join "," profiles) "deps" :env {"LEIN_HOME" lein-home})))))
+        (sh/sh "lein" "with-profiles" (string/join "," (cons "user" profiles)) "deps" :env {"LEIN_HOME" lein-home})))))
 
 (defn- add-to-nix-store!
   [{:keys [local-path lib rev] :as dep}]


### PR DESCRIPTION
This PR changes/fixes 3 small things that improve the usage of clj-nix for Leiningen users:

- Fixing the faulty assertions for the `withLeiningen` module option (closes #144 )
- Propagating `withLeiningen` to the derivation as `enableLeiningen` (so the option actually does something)
- Adding an option `--lein-profiles` to the deps-lock CLI that allows one to set the profile(s) to use when generating the lock file. This is useful to have because currently, all custom profiles are merged (which can result in unwanted configuration outcomes that break the build, e.g. due to `:repositories` or `:offline?` options).