### PR TITLE
Fix snapshot version support for leiningen

### DIFF
--- a/src/cljnix/core.clj
+++ b/src/cljnix/core.clj
@@ -173,7 +173,9 @@
             (remove deps-set)
             (map (fn [mvn-path]
                    (let [full-path (fs/path cache-dir mvn-path)]
-                     (assoc (utils/mvn-repo-info full-path {:cache-dir cache-dir :mvn-repos mvn-repos})
+                     ; Setting :exact-version to "SNAPSHOT" here should be fine – if the path isn't a snapshot, it doesn't
+                     ; matter, and if it is, mvn-repo-info should return the correct result
+                     (assoc (utils/mvn-repo-info full-path {:exact-version "SNAPSHOT" :cache-dir cache-dir :mvn-repos mvn-repos})
                             :hash (nix-hash full-path))))))
 
           (fs/glob cache-dir "**.{pom,jar}"))))


### PR DESCRIPTION
It's me again, fixing Leiningen stuff as I encounter it.

The current code doesn't support the use of snapshot version from Leiningen, due to the caching being implemented via `missing-mvn-deps`. Here's the error you encounter if you try, for reference:

<details><summary>Error</summary>

```clojure
{:clojure.main/message
 "Execution error (AssertionError) at cljnix.utils/mvn-repo-info (utils.clj:134).\nAssert failed: (if (snapshot? path) (not (nil? exact-version)) true)\n",
 :clojure.main/triage
 {:clojure.error/class java.lang.AssertionError,
  :clojure.error/line 134,
  :clojure.error/cause
  "Assert failed: (if (snapshot? path) (not (nil? exact-version)) true)",
  :clojure.error/symbol cljnix.utils/mvn-repo-info,
  :clojure.error/source "utils.clj",
  :clojure.error/phase :execution},
 :clojure.main/trace
 {:via
  [{:type java.lang.AssertionError,
    :message
    "Assert failed: (if (snapshot? path) (not (nil? exact-version)) true)",
    :at [cljnix.utils$mvn_repo_info invokeStatic "utils.clj" 134]}],
  :trace
  [[cljnix.utils$mvn_repo_info invokeStatic "utils.clj" 134]
   [cljnix.utils$mvn_repo_info doInvoke "utils.clj" 134]
   [clojure.lang.RestFn invoke "RestFn.java" 423]
   [cljnix.core$missing_mvn_deps$fn__22429 invoke "core.clj" 176]
   [clojure.core$map$fn__5931$fn__5932 invoke "core.clj" 2759]
   [clojure.core$filter$fn__5958$fn__5959 invoke "core.clj" 2823]
   [clojure.core$map$fn__5931$fn__5932 invoke "core.clj" 2759]
   [clojure.core$map$fn__5931$fn__5932 invoke "core.clj" 2759]
   [clojure.core$filter$fn__5958$fn__5959 invoke "core.clj" 2823]
   [clojure.lang.PersistentVector reduce "PersistentVector.java" 343]
   [clojure.core$transduce invokeStatic "core.clj" 6947]
   [clojure.core$into invokeStatic "core.clj" 6963]
   [clojure.core$into invoke "core.clj" 6951]
   [cljnix.core$missing_mvn_deps invokeStatic "core.clj" 168]
   [cljnix.core$missing_mvn_deps invoke "core.clj" 160]
   [cljnix.core$lock_file$fn__22521 invoke "core.clj" 398]
   [clojure.core$completing$fn__8528 invoke "core.clj" 6931]
   [clojure.core$map$fn__5931$fn__5932 invoke "core.clj" 2757]
   [clojure.core$cat$fn__8851 invoke "core.clj" 7696]
   [clojure.core$map$fn__5931$fn__5932 invoke "core.clj" 2757]
   [clojure.core$map$fn__5931$fn__5932 invoke "core.clj" 2757]
   [clojure.core$transduce invokeStatic "core.clj" 6949]
   [clojure.core$transduce invoke "core.clj" 6934]
   [cljnix.core$lock_file invokeStatic "core.clj" 381]
   [cljnix.core$lock_file invoke "core.clj" 372]
   [cljnix.core$_main invokeStatic "core.clj" 508]
   [cljnix.core$_main doInvoke "core.clj" 503]
   [clojure.lang.RestFn applyTo "RestFn.java" 137]
   [clojure.lang.Var applyTo "Var.java" 705]
   [clojure.core$apply invokeStatic "core.clj" 667]
   [clojure.main$main_opt invokeStatic "main.clj" 514]
   [clojure.main$main_opt invoke "main.clj" 510]
   [clojure.main$main invokeStatic "main.clj" 664]
   [clojure.main$main doInvoke "main.clj" 616]
   [clojure.lang.RestFn applyTo "RestFn.java" 137]
   [clojure.lang.Var applyTo "Var.java" 705]
   [clojure.main main "main.java" 40]],
  :cause
  "Assert failed: (if (snapshot? path) (not (nil? exact-version)) true)"}}
```

</details> 

I've spent some time debugging and trying to understand the logic of `mvn-repo-info`, and while I'm not entirely sure I get it, I found that simply setting the `:exact-version` of any "missing dep" to `"SNAPSHOT"` would circumvent the issue because it results in the desired behaviour.

I realise that this might be a hack. Let me know if there is a flaw in what I've done here or if you see other ways to mitigate the issue.