### PR TITLE
Remove "exact-version" argument from mvn-repo-info

### DIFF
--- a/src/cljnix/core.clj
+++ b/src/cljnix/core.clj
@@ -36,16 +36,17 @@
           (map (fn [[lib {:keys [mvn/version paths]}]]
                  (when-not (= 1 (count paths))
                    (throw+ "Maven deps can have only 1 path" {:lib lib :paths paths}))
-                 (let [local-path (first paths)]
-                   (assoc (utils/mvn-repo-info local-path {:exact-version version :mvn-repos mvn-repos})
-                          :lib lib
-                          :version version
-                          :local-path local-path))))
+                 (let [local-path (-> paths first (utils/fixed-snapshot-path version))
+                       result (assoc (utils/mvn-repo-info local-path {:mvn-repos mvn-repos})
+                                     :lib lib
+                                     :version version
+                                     :local-path local-path)]
+                   result)))
           ; Add POM
           (mapcat (juxt identity
                         (fn [{:keys [local-path version]}]
-                          (let [pom-path (utils/artifact->pom local-path)]
-                            (assoc (utils/mvn-repo-info pom-path {:exact-version version :mvn-repos mvn-repos})
+                          (let [pom-path (-> local-path utils/artifact->pom (utils/fixed-snapshot-path version))]
+                            (assoc (utils/mvn-repo-info pom-path {:mvn-repos mvn-repos})
                                    :version version
                                    :local-path pom-path)))))
 

--- a/test/cljnix/utils_test.clj
+++ b/test/cljnix/utils_test.clj
@@ -34,7 +34,21 @@
           :mvn-repo "https://repo.clojars.org/"
           :url "https://repo.clojars.org/babashka/fs/0.1.5/fs-0.1.5.jar"}
          (utils/mvn-repo-info
-           (fs/path @mvn/cached-local-repo "babashka/fs/0.1.5/fs-0.1.5.jar")))))
+           (fs/path @mvn/cached-local-repo "babashka/fs/0.1.5/fs-0.1.5.jar"))))
+
+  (is (= {:mvn-path "clj-kondo/clj-kondo/2022.04.26-SNAPSHOT/clj-kondo-2022.04.26-20220502.201054-5.jar"
+          :mvn-repo "https://repo.clojars.org/"
+          :url "https://repo.clojars.org/clj-kondo/clj-kondo/2022.04.26-SNAPSHOT/clj-kondo-2022.04.26-20220502.201054-5.jar"
+          :snapshot "clj-kondo-2022.04.26-SNAPSHOT.jar"}
+         (utils/mvn-repo-info
+           (fs/path @mvn/cached-local-repo "clj-kondo/clj-kondo/2022.04.26-SNAPSHOT/clj-kondo-2022.04.26-20220502.201054-5.jar"))))
+
+  (is (= {:mvn-repo "https://repo.clojars.org/",
+          :mvn-path "clj-kondo/clj-kondo/2022.04.26-SNAPSHOT/clj-kondo-2022.04.26-20220526.212013-27.jar",
+          :url "https://repo.clojars.org/clj-kondo/clj-kondo/2022.04.26-SNAPSHOT/clj-kondo-2022.04.26-20220526.212013-27.jar",
+          :snapshot "clj-kondo-2022.04.26-SNAPSHOT.jar"}
+         (utils/mvn-repo-info
+           (fs/path @mvn/cached-local-repo "clj-kondo/clj-kondo/2022.04.26-SNAPSHOT/clj-kondo-2022.04.26-SNAPSHOT.jar")))))
 
 (deftest get-parent-test
   (is (= (str (fs/path @mvn/cached-local-repo "org/clojure/pom.contrib/1.1.0/pom.contrib-1.1.0.pom"))


### PR DESCRIPTION
Needed to add SNAPSHOT version support for leiningen, while keeping fixed snapshot version support (e.g: `foo-1.0-20220502.201054-5`) for deps.edn