### PR TITLE
add: nativeImage.static for musl static linking

### DIFF
--- a/helpers.nix
+++ b/helpers.nix
@@ -87,11 +87,22 @@ in
         }
 
     else if cfg.nativeImage.enable then
-      pkgs'.mkGraalBin
-        {
-          inherit cljDrv;
-          inherit (cfg.nativeImage) graalvm extraNativeImageBuildArgs graalvmXmx;
-        }
+      pkgs'.mkGraalBin {
+        inherit cljDrv;
+
+        graalvm = if cfg.nativeImage.static then
+          pkgs'.graalvmPackages.graalvm-ce-musl
+        else
+          cfg.nativeImage.graalvm;
+
+        extraNativeImageBuildArgs = cfg.nativeImage.extraNativeImageBuildArgs
+          ++ (if cfg.nativeImage.static then [
+            "--static"
+            "--libc=musl"
+          ] else
+            [ ]);
+        inherit (cfg.nativeImage) graalvmXmx;
+      }
     else
       cljDrv;
 

--- a/modules/top-level.nix
+++ b/modules/top-level.nix
@@ -180,6 +180,12 @@ let types = lib.types; in
             description = "XMX size of GraalVM during build";
           };
 
+          static = lib.mkOption {
+            default = false;
+            type = types.bool;
+            description = "Build a static binary using musl libc";
+          };
+
         };
       };
     };


### PR DESCRIPTION
for your consideration.

I've tried to add some asserts or warnings when someone sets both `static = true;` and `graalvm` to keep musl compatibility in mind but my nix-fu is not strong enough.