### PR TITLE
Add uber-options to configure the default builder

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -60,6 +60,10 @@ default are mandatory, extra attributes are passed to **mkDerivation**):
   Needed if the projects contains java source files. Only 2 options are
   supoorted: `src-dirs` and `javac-opts`. (Default: `null`)
 
+- **uberOpts**: Options passed to
+  [`uber`](https://clojure.github.io/tools.build/clojure.tools.build.api.html#var-uber)
+  Only 1 option is supported: `exclude`. (Default: `null`)
+
 - **enableLeiningen**: Makes Leiningen accessible at build time (Default:
   `false`)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -62,6 +62,7 @@ default are mandatory, extra attributes are passed to **mkDerivation**):
 
 - **uberOpts**: Options passed to
   [`uber`](https://clojure.github.io/tools.build/clojure.tools.build.api.html#var-uber)
+  See [TBUILD-11](https://clojure.atlassian.net/browse/TBUILD-11) for when you might need it.
   Only 1 option is supported: `exclude`. (Default: `null`)
 
 - **enableLeiningen**: Makes Leiningen accessible at build time (Default:

--- a/helpers.nix
+++ b/helpers.nix
@@ -55,7 +55,7 @@ in
     );
 
     assert (pkgs'.lib.assertMsg
-      (cfg.withLeiningen == true -> isNull cfg.compileCljOpts && isNull cfg.javacOpts)
+      (cfg.withLeiningen == true -> isNull cfg.compileCljOpts && isNull cfg.javacOpts && isNull cfg.uberOpts)
       "Leiningen is incompatible with Clojure tools.build options (compileCljOpts and javacOpts)"
     );
 

--- a/modules/top-level.nix
+++ b/modules/top-level.nix
@@ -101,6 +101,18 @@ let types = lib.types; in
       );
     };
 
+    uberOpts = lib.mkOption {
+      default = null;
+      description = "Options passed to uber.";
+      type = types.nullOr (
+        (types.submodule {
+          options.exclude = lib.mkOption {
+            type = types.listOf types.str;
+          };
+        })
+      );
+    };
+
     withLeiningen = lib.mkOption {
       default = false;
       description = "Enable it to invoke leiningen during the build";

--- a/pkgs/mkCljBin.nix
+++ b/pkgs/mkCljBin.nix
@@ -29,6 +29,7 @@
 , lockfile ? null
 , compileCljOpts ? null
 , javacOpts ? null
+, uberOpts ? null
 , enableLeiningen ? false
 , builder-extra-inputs ? [ ]
 , builder-java-opts ? [ ]
@@ -55,6 +56,7 @@ let
     "nativeBuildInputs"
     "compileCljOpts"
     "javacOpts"
+    "uberOpts"
     "builder-extra-inputs"
     "builder-java-opts"
     "builder-preBuild"
@@ -150,7 +152,8 @@ stdenv.mkDerivation ({
         ''
           clj-builder uber "${fullId}" "${version}" "${main-ns}" \
             '${builtins.toJSON compileCljOpts}' \
-            '${builtins.toJSON javacOpts}'
+            '${builtins.toJSON javacOpts}' \
+            '${builtins.toJSON uberOpts}'
         ''
 
       # Don't check for :gen-class with custom build commands

--- a/src/cljnix/build.clj
+++ b/src/cljnix/build.clj
@@ -58,7 +58,7 @@
                          version)}))
 
 (defn uber
-  [{:keys [main-ns compile-clj-opts javac-opts] :as opts}]
+  [{:keys [main-ns compile-clj-opts javac-opts uber-opts] :as opts}]
   (let [{:keys [src-dirs basis output-jar]}
         (common-compile-options opts)]
     (b/copy-dir {:src-dirs src-dirs
@@ -73,10 +73,11 @@
                             :class-dir class-dir}
                      compile-clj-opts (merge (parse-compile-clj-opts compile-clj-opts))))
 
-    (b/uber {:class-dir class-dir
-             :uber-file output-jar
-             :basis basis
-             :main main-ns})))
+    (b/uber (cond-> {:class-dir class-dir
+                     :uber-file output-jar
+                     :basis basis
+                     :main main-ns}
+              uber-opts (merge uber-opts)))))
 
 (defn jar
   [{:keys [version] :as opts}]

--- a/src/cljnix/builder_cli.clj
+++ b/src/cljnix/builder_cli.clj
@@ -34,9 +34,10 @@
     (= cmd "uber")
     (do
       (check-main-class args)
-      (-> (zipmap [:lib-name :version :main-ns :compile-clj-opts :javac-opts] args)
+      (-> (zipmap [:lib-name :version :main-ns :compile-clj-opts :javac-opts :uber-opts] args)
           (update :compile-clj-opts str->json)
           (update :javac-opts str->json)
+          (update :uber-opts str->json)
           (build/uber)))
 
     (= cmd "check-main")


### PR DESCRIPTION
Can be used to exclude certain files from deps when building an uber-jar with the default-builder.

Resolves jlesquembre/clj-nix#163

Example:

```
        clj-nix.packages.${system}.mkCljBin rec {
          projectSrc = ./.;
          name = "polly";
          main-ns = "app.server";
          jdkRunner = pkgs.jdk17;

          uberOpts = {
            exclude = [
              "^META-INF/license/.*"
            ];
          };
        };
```