### PR TITLE
Add option to symlink Clojure dependencies during build

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -68,6 +68,10 @@ default are mandatory, extra attributes are passed to **mkDerivation**):
 - **enableLeiningen**: Makes Leiningen accessible at build time (Default:
   `false`)
 
+- **symlinkDeps**: Symlink the Clojure dependencies to the directory where the
+  `buildCommand` is executed, providing compatibility with other commands that
+  might need a mutable `$HOME` (like `npm`). (Default: `false`)
+
 - **builder-extra-inputs**: Extra inputs to the default builder (Default: `[ ]`)
 
 - **builder-java-opts** List of Java options to include in default builder

--- a/pkgs/mkCljBin.nix
+++ b/pkgs/mkCljBin.nix
@@ -31,6 +31,7 @@
 , javacOpts ? null
 , uberOpts ? null
 , enableLeiningen ? false
+, symlinkDeps ? false
 , builder-extra-inputs ? [ ]
 , builder-java-opts ? [ ]
 , builder-preBuild ? ""
@@ -135,8 +136,10 @@ stdenv.mkDerivation ({
     ''
       runHook preBuild
 
-      export HOME="${deps-cache}"
-      export JAVA_TOOL_OPTIONS="-Duser.home=${deps-cache}"
+      export HOME="${if symlinkDeps then "$(pwd)" else "${deps-cache}"}"
+      export JAVA_TOOL_OPTIONS="-Duser.home=$HOME"
+
+      ${lib.optionalString symlinkDeps "ln -s ${deps-cache}/.* $HOME"}
 
       export CLJ_CONFIG="$HOME/.clojure"
       export CLJ_CACHE="$TMP/cp_cache"


### PR DESCRIPTION
I'm often finding myself building projects that use Clojure + ClojureScript (with `shadow-cljs`), with an artifact uberjar that contains the Clojure backend and some compiled JavaScript code for the frontend. In order for the build commands to be identical for both local development and Nix builds, I'm usually building the frontend stuff in my `build.clj`. This involves using `npm` at some point during the `buildPhase`.

`npm` expects `$HOME` to point to a mutable location, but `clj-nix` sets `$HOME` to the immutable location of the Clojure dependencies. This PR introduces an option to symlink the Clojure dependencies to the `pwd` (and setting `HOME` to that) during the `buildPhase` instead, making it possible to use `mkCljBin` to build such projects instead of having to reverse enginner it :)