### PR TITLE
Unbreak `mkGraalBin`

### DIFF
--- a/pkgs/mkGraalBin.nix
+++ b/pkgs/mkGraalBin.nix
@@ -79,7 +79,7 @@ buildGraalvmNativeImage ({
   meta.mainProgram = name;
 
   dontUnpack = true;
-  jar = lib.fileContents "${cljDrv}/nix-support/jar-path";
+  src = lib.fileContents "${cljDrv}/nix-support/jar-path";
 
   extraNativeImageBuildArgs = extraNativeImageBuildArgs ++
     [

--- a/pkgs/mkGraalBin.nix
+++ b/pkgs/mkGraalBin.nix
@@ -76,6 +76,7 @@ buildGraalvmNativeImage ({
   inherit version;
   pname = name;
   graalvmDrv = graalvm;
+  meta.mainProgram = name;
 
   dontUnpack = true;
   jar = lib.fileContents "${cljDrv}/nix-support/jar-path";


### PR DESCRIPTION
I initially wanted to tackle #102, but in order to do that, I needed to fix the CI first :) There's also an open question at the bottom on whether we need to update `nixpkgs`.

There were 2 separate issues with `mkGraalBin`:

### `meta.mainProgram` was unset

It needs to be set nowadays.
<details>
<summary>This was the error I encountered:</summary>

```shell
 ✗ nix build .#mkGraalBin-test
   tags: graal
   (in test file test/new_project.bats, line 62)
     `nix build .#mkGraalBin-test --print-out-paths >> "$DERIVATIONS"' failed
   warning: Git tree '/tmp/bats-run-BPSCjM/file/0/clj-nix_project' is dirty
   building '/nix/store/jzmx5d9zny758g0wwzzcry8gk5hvv123-cljdemo-DEV.drv'...
   this derivation will be built:
     /nix/store/2605drl2bgw5dbdc7m898p598ix4v505-cljdemo-DEV.drv
   building '/nix/store/2605drl2bgw5dbdc7m898p598ix4v505-cljdemo-DEV.drv'...
   error: builder for '/nix/store/2605drl2bgw5dbdc7m898p598ix4v505-cljdemo-DEV.drv' failed with exit code 20;
          last 20 log lines:
          > /build/.attrs.sh: line 1: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
          > structuredAttrs is enabled
          > /nix/store/nivcx63drxqzm6pic6vm2wbkxl368w83-stdenv-linux/setup: line 592: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
          > Running phase: patchPhase
          > Running phase: updateAutotoolsGnuConfigScriptsPhase
          > Running phase: configurePhase
          > no configure script, doing nothing
          > Running phase: buildPhase
          > Error: /build is a directory. (-jar requires a valid jarfile)
          > com.oracle.svm.driver.NativeImage$NativeImageError: /build is a directory. (-jar requires a valid jarfile)
          >        at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.showError(NativeImage.java:2422)
          >    at org.graalvm.nativeimage.driver/com.oracle.svm.driver.DefaultOptionHandler.handleJarFileArg(DefaultOptionHandler.java:223)
          >    at org.graalvm.nativeimage.driver/com.oracle.svm.driver.DefaultOptionHandler.consume(DefaultOptionHandler.java:113)
          >     at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage$NativeImageArgsProcessor.apply(NativeImage.java:2120)
          >       at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.processNativeImageArgs(NativeImage.java:2461)
          >       at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.completeImageBuild(NativeImage.java:1141)
          >   at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.build(NativeImage.java:2006)
          >        at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.performBuild(NativeImage.java:1971)
          >         at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.main(NativeImage.java:1953)
          >         at java.base@24.0.1/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
          For full logs, run:
            nix log /nix/store/2605drl2bgw5dbdc7m898p598ix4v505-cljdemo-DEV.drv
```
</details>

### Recent changes to `buildGraalvmNativeImage`
See https://github.com/NixOS/nixpkgs/commit/4d134f63fdebb45b9f723c99f635617c8acf50e9: Its API is now "inherited" from `mkDerivation`, so we need to use `src` instead of `jar`.

### TODO we should probably update `nixpkgs`

The `bats` tests, as far as I understand, use the "template template" and always create a new and recent `flake.lock` during runs, which is why we see breakage in newer CI runs (the commit above is ~2 weeks old only). But still my changes only work because the template also sets `clj-nix.inputs.nixpkgs.follows = "nixpkgs"`. So in order to not break things for people who don't override the `nixpkgs` input (and still fix it for those who do :grin:) we should most likely also update `nixpkgs`. What do you think; should I do this as part of the commit?