### PR TITLE
fix: add `meta.mainProgram` in `mkCljBin`

### DIFF
--- a/pkgs/mkCljBin.nix
+++ b/pkgs/mkCljBin.nix
@@ -81,6 +81,8 @@ stdenv.mkDerivation ({
   pname = lib.strings.sanitizeDerivationName artifactId;
   src = projectSrc;
 
+  meta.mainProgram = artifactId;
+
   # Build time deps
   nativeBuildInputs =
     attrs.nativeBuildInputs or [ ]


### PR DESCRIPTION
I didn't realize earlier on (when doing the same for `mkGraalBin` for #166) that `mkCljBin` would also have the same problem. We can safely set `meta.mainProgram` to the `artifactId` here as that is later used to create `$out/bin/${artifactId}`.

(I've also removed an unused binding.)