### PR TITLE
Update deprecated GitHub Action for CloudFlare Pages.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,8 @@ jobs:
           publish_dir: ./result
 
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: clj-nix
-          directory: result
+          command: pages deploy result --project-name=clj-nix


### PR DESCRIPTION
Tested with GitHub Actions and CloudFlare pages and it works fine.

I'll be sending more pull requests with much more significant changes.