### PR TITLE
Clean up and fix test and GitHub Actions:

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,20 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Clojure tests
+      - name: Warm Nix devShell
         run: |
-          nix develop --command kaocha
+          nix develop --command echo
 
-      - name: Integration tests
+      - name: "Tests: Unit"
         run: |
-          nix develop --command bats --timing test
+          nix develop --command tests-unit
+
+      - name: "Tests: Integration"
+        run: |
+          nix develop --command tests-integration
+
+      - name: "Tests: End-to-end"
+        run: |
+          nix develop --command tests-e2e
           echo "Derivations:"
           cat "/tmp/.cljnix-derivations"

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -14,13 +14,10 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
 
       - name: Update clj dependencies
-        run:
-          nix develop --command clojure -Sdeps '{:deps {com.github.liquidz/antq
-          {:mvn/version "RELEASE"}}}' -M -m antq.core -d . --upgrade --force
-          --skip=github-action
+        run: nix develop --command update-clojure-deps
 
       - name: Update clojure lock files
-        run: "nix develop --command update-deps"
+        run: nix develop --command update-lock-files
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8

--- a/flake.nix
+++ b/flake.nix
@@ -69,37 +69,42 @@
             ];
             commands = [
               {
-                name = "update-deps";
-                help = "Update builder-lock.json and clojure-deps.edn";
-                command =
-                  ''
-                    bb ./scripts/newer_clojure_versions.bb
-                    clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' -M -m antq.core --upgrade --force
-                    clj -X cljnix.bootstrap/as-json :deps-path '"deps.edn"' | jq . > pkgs/builder-lock.json
-                    clj -X cljnix.core/clojure-deps-str > src/clojure-deps.edn
-                    (cd ./templates/default && nix run ../..#deps-lock)
-                    (cd ./test/leiningen-example-project && nix run ../..#deps-lock -- --lein --lein-profiles foobar && mv deps-lock.json deps-lock-foobar-profile.json)
-                    (cd ./test/leiningen-example-project && nix run ../..#deps-lock -- --lein)
-                  '';
+                name = "update-clojure-deps";
+                category = "dependencies";
+                help = "Update Clojure dependency versions in deps.edn";
+                command = ''
+                  clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' -M \
+                    -m antq.core \
+                    -d . \
+                    --upgrade \
+                    --force \
+                    --skip=github-action
+                '';
               }
               {
-                name = "kaocha";
-                help = "Run tests with kaocha";
-                command =
-                  ''
-                    clojure -M:test -m kaocha.runner "$@"
-                  '';
-              }
-              {
-                name = "tests";
-                help = "Run tests with bats";
-                command =
-                  ''
-                    bats --timing test
-                  '';
+                name = "update-lock-files";
+                category = "dependencies";
+                help = "Regenerate all builder-lock.json and deps-lock.json files";
+                command = ''
+                  bb ./scripts/newer_clojure_versions.bb
+                  clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' \
+                    -M \
+                    -m antq.core \
+                    --upgrade \
+                    --force
+                  clj -X cljnix.bootstrap/as-json :deps-path '"deps.edn"' | jq . > pkgs/builder-lock.json
+                  clj -X cljnix.core/clojure-deps-str > src/clojure-deps.edn
+                  (cd ./templates/default && nix run ../..#deps-lock)
+                  (cd ./test/leiningen-example-project && \
+                    nix run ../..#deps-lock -- --lein --lein-profiles foobar && \
+                    mv deps-lock.json deps-lock-foobar-profile.json)
+                  (cd ./test/leiningen-example-project && \
+                    nix run ../..#deps-lock -- --lein)
+                '';
               }
               {
                 name = "dummy-project";
+                category = "scaffolding";
                 help = "Creates a dummy clj-nix project";
                 command =
                   ''
@@ -109,6 +114,67 @@
                     echo 'cljnixUrl: ${self}' | mustache "${self}/test/integration/flake.template" > "$project_dir/flake.nix"
                     echo "New dummy project: $project_dir"
                   '';
+              }
+              {
+                name = "tests-unit";
+                category = "test categories";
+                help = "Run Clojure unit tests";
+                command = ''
+                  clojure -M:test -m kaocha.runner :unit "$@"
+                '';
+              }
+              {
+                name = "tests-integration";
+                category = "test categories";
+                help = "Run Clojure integration tests";
+                command = ''
+                  clojure -M:test -m kaocha.runner :integration "$@"
+                '';
+              }
+              {
+                name = "tests-e2e";
+                category = "test categories";
+                help = "Run end-to-end tests with bats";
+                command = ''
+                  bats --timing test
+                '';
+              }
+              {
+                name = "tests-all";
+                category = "test categories";
+                help = "Run all tests (Clojure and bats)";
+                command = ''
+                  echo "Running Clojure unit tests..."
+                  clojure -M:test -m kaocha.runner :unit
+                  echo "Running Clojure integration tests..."
+                  clojure -M:test -m kaocha.runner :integration
+                  echo "Running bats end-to-end tests..."
+                  bats --timing test
+                '';
+              }
+              {
+                name = "tests-bats";
+                category = "test runners";
+                help = "Run bats test runner (defaults to test directory if no args provided)";
+                command = ''
+                  if [ $# -eq 0 ]; then
+                    bats --timing test
+                  else
+                    bats "$@"
+                  fi
+                '';
+              }
+              {
+                name = "tests-kaocha";
+                category = "test runners";
+                help = "Run kaocha test runner with optional parameters";
+                command = ''
+                  if [ $# -eq 0 ]; then
+                    clojure -M:test -m kaocha.runner
+                  else
+                    clojure -M:test -m kaocha.runner "$@"
+                  fi
+                '';
               }
             ];
           };

--- a/test/integration/flake.template
+++ b/test/integration/flake.template
@@ -16,17 +16,39 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         cljpkgs = clj-nix.packages."${system}";
+
+        # Detect if we're on macOS and need to use Linux packages for containers
+        isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+        linuxSystem = if pkgs.stdenv.hostPlatform.isAarch64 then "aarch64-linux" else "x86_64-linux";
+
+        # Use native Linux packages for containers (requires remote builders on macOS)
+        containerPkgs = if isDarwin then nixpkgs.legacyPackages.${linuxSystem} else pkgs;
+        containerCljpkgs = if isDarwin then clj-nix.packages.${linuxSystem} else cljpkgs;
+
+        # Common function to build a Clojure binary (reusable for containers)
+        mkCljBinFor = pkgsSet: cljpkgsSet:
+          cljpkgsSet.mkCljBin {
+            projectSrc = ./.;
+            name = "me.lafuente/cljdemo";
+            main-ns = "hello.core";
+            jdkRunner = pkgsSet.jdk17_headless;
+          };
+
+        # Container-specific builds (Linux on macOS, native on Linux)
+        containerCljBin = mkCljBinFor containerPkgs containerCljpkgs;
+        containerCustomJdk = containerCljpkgs.customJdk {
+          cljDrv = containerCljBin;
+          locales = "en,es";
+        };
+        containerGraalBin = containerCljpkgs.mkGraalBin {
+          cljDrv = containerCljBin;
+        };
       in
 
       {
         packages = {
 
-          mkCljBin-test = cljpkgs.mkCljBin {
-            projectSrc = ./.;
-            name = "me.lafuente/cljdemo";
-            main-ns = "hello.core";
-            jdkRunner = pkgs.jdk17_headless;
-          };
+          mkCljBin-test = mkCljBinFor pkgs cljpkgs;
 
           customJdk-test = cljpkgs.customJdk {
             cljDrv = self.packages."${system}".mkCljBin-test;
@@ -37,26 +59,22 @@
             cljDrv = self.packages."${system}".mkCljBin-test;
           };
 
-          jvm-container-test =
-            pkgs.dockerTools.buildLayeredImage {
-              name = "jvm-container-test";
-              tag = "latest";
-              config = {
-                Cmd = clj-nix.lib.mkCljCli { jdkDrv = self.packages."${system}".customJdk-test; };
-              };
+          # Build Linux containers for Docker, even on macOS
+          jvm-container-test = containerPkgs.dockerTools.buildLayeredImage {
+            name = "jvm-container-test";
+            tag = "latest";
+            config = {
+              Cmd = clj-nix.lib.mkCljCli { jdkDrv = containerCustomJdk; };
             };
+          };
 
-          graal-container-test =
-            let
-              graalDrv = self.packages."${system}".mkGraalBin-test;
-            in
-            pkgs.dockerTools.buildLayeredImage {
-              name = "graal-container-test";
-              tag = "latest";
-              config = {
-                Cmd = [ "${graalDrv}/bin/${graalDrv.pname}" ];
-              };
+          graal-container-test = containerPkgs.dockerTools.buildLayeredImage {
+            name = "graal-container-test";
+            tag = "latest";
+            config = {
+              Cmd = [ "${containerGraalBin}/bin/${containerGraalBin.pname}" ];
             };
+          };
 
           babashka-test = cljpkgs.mkBabashka { };
 

--- a/test/new_project.bats
+++ b/test/new_project.bats
@@ -9,6 +9,13 @@ container_runtime() {
   fi
 }
 
+# Skip container tests on macOS unless remote builders are configured
+skip_if_darwin_without_remote_builders() {
+  if [[ "$OSTYPE" == "darwin"* ]] && ! nix show-config | grep -q "builders.*ssh"; then
+    skip "Container tests require Linux remote builders on macOS (see: https://nixos.org/manual/nix/stable/advanced-topics/distributed-builds.html)"
+  fi
+}
+
 setup_file() {
 
   bats_require_minimum_version 1.5.0
@@ -75,6 +82,7 @@ teardown_file() {
 
 # bats test_tags=docker
 @test "nix build .#jvm-container-test" {
+    skip_if_darwin_without_remote_builders
     nix build .#jvm-container-test --print-out-paths >> "$DERIVATIONS"
     $(container_runtime) load -i result
     run -0 "$(container_runtime)" run --rm jvm-container-test:latest
@@ -83,6 +91,7 @@ teardown_file() {
 
 # bats test_tags=docker,graal
 @test "nix build .#graal-container-test" {
+    skip_if_darwin_without_remote_builders
     nix build .#graal-container-test --print-out-paths >> "$DERIVATIONS"
     $(container_runtime) load -i result
     run -0 "$(container_runtime)" run --rm graal-container-test:latest


### PR DESCRIPTION
Docker container tests were failing on macOS because they built macOS binaries instead of Linux binaries. This commit fixes the issue by detecting the host platform and using appropriate Linux packages for container builds.

Changes:

* Clean up Nix devShell commands and GitHub actions:
  * Nix devShell commands: rename, add categories, clarify
  * GitHub Actions: move logic to devShell commands to simplify

* Add test filtering support to the 'tests' command by passing arguments through to bats (enables: tests --filter <pattern>)

* Detect macOS and automatically use Linux packages for Docker container builds (requires remote builders on macOS)

* Refactor container builds to eliminate code duplication using a shared helper function and pre-built derivations

* Skip container tests on macOS when remote builders are not configured, with helpful guidance on setting up distributed builds

Container images now always contain Linux binaries compatible with Docker, whether built on Linux (natively) or macOS (via remote builders).